### PR TITLE
Reverse engineer python script for flag

### DIFF
--- a/eat.py
+++ b/eat.py
@@ -1,0 +1,63 @@
+# I wrote and debugged this code with all the convoluted "EAT" variable names.
+# Was it confusing? Yes. Was debugging hard? Yes.
+# Did I spend more time than I should have on this problem? Yes
+
+EAT = int
+eAT = len
+EaT = print
+ATE = str
+EATEATEATEATEATEAT = ATE.isdigit
+
+def Eating(eat):
+    return ATE(EAT(eat)*EATEATEAT)
+
+def EAt(eat, eats):
+    print(eat, eats)
+    eat1 = 0
+    eat2 = 0
+    eateat = 0
+    eAt = ""
+    while eat1 < eAT(eat) and eat2 < eAT(eats):
+        if eateat%EATEATEAT == EATEATEATEATEAT//EATEATEATEAT:
+            eAt += eats[eat2]
+            eat2 += 1
+        else:
+            eAt += eat[eat1]
+            eat1 += 1
+        eateat += 1
+    return eAt
+
+def aten(eat):
+    return eat[::EATEATEAT-EATEATEATEAT]
+
+def eaT(eat):
+    return Eating(eat[:EATEATEAT]) + aten(eat)
+
+def aTE(eat):
+    return eat#*eAT(eat)
+
+def Ate(eat):
+    return "Eat" + ATE(eAT(eat)) + eat[:EATEATEAT]
+
+def Eat(eat):
+    if eAT(eat) == 9:
+        if EATEATEATEATEATEAT(eat[:EATEATEAT]) and\
+            EATEATEATEATEATEAT(eat[eAT(eat)-EATEATEAT+1:]):
+                eateat = EAt(eaT(eat), Ate(aTE(aten(eat))))
+                if eateat == "E10a23t9090t9ae0140":
+                    flag = "eaten_" + eat
+                    EaT("absolutely EATEN!!! CTFlearn{",flag,"}")
+                else:
+                    EaT("thats not the answer. you formatted it fine tho, here's what you got\n>>", eateat)
+        else:
+            EaT("thats not the answer. bad format :(\
+            \n(hint: 123abc456 is an example of good format)")
+    else:
+        EaT("thats not the answer. bad length :(")
+
+EaT("what's the answer")
+eat = input()
+EATEATEAT = eAT(eat)//3
+EATEATEATEAT = EATEATEAT+1
+EATEATEATEATEAT = EATEATEAT-1
+Eat(eat)


### PR DESCRIPTION
Add `eat.py` challenge file, which was reverse-engineered to find the CTF flag.

The `eat.py` file contains a Python script that requires a specific 9-character input to output a flag. The script uses obfuscated variable names and string manipulation functions to validate the input. The solution involved analyzing these functions to determine the correct input string.

---
<a href="https://cursor.com/background-agent?bcId=bc-9aa19218-4bb5-4457-ad1d-09ad53ba2180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9aa19218-4bb5-4457-ad1d-09ad53ba2180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

